### PR TITLE
Handle selection events and fix page numbers

### DIFF
--- a/src/UI/edit.js
+++ b/src/UI/edit.js
@@ -16,6 +16,7 @@ import {
   scaleDown,
   scaleUp
 } from './utils';
+import { fireEvent } from '../UI/event';
 
 let _enabled = false;
 let isDragging = false, overlay;
@@ -37,7 +38,7 @@ function createEditOverlay(target) {
   let rect = getAnnotationRect(target);
   let styleLeft = rect.left - OVERLAY_BORDER_SIZE;
   let styleTop = rect.top - OVERLAY_BORDER_SIZE;
-  
+
   overlay.setAttribute('id', 'pdf-annotate-edit-overlay');
   overlay.setAttribute('data-target-id', id);
   overlay.style.boxSizing = 'content-box';
@@ -64,7 +65,7 @@ function createEditOverlay(target) {
   anchor.style.right = '-13px';
   anchor.style.width = '25px';
   anchor.style.height = '25px';
-  
+
   overlay.appendChild(anchor);
   parentNode.appendChild(overlay);
   document.addEventListener('click', handleDocumentClick);
@@ -120,7 +121,7 @@ function deleteAnnotation() {
   [...nodes].forEach((n) => {
     n.parentNode.removeChild(n);
   });
-  
+
   PDFJSAnnotate.getStoreAdapter().deleteAnnotation(documentId, annotationId);
 
   destroyEditOverlay();
@@ -224,8 +225,8 @@ function handleDocumentMouseup(e) {
   let target = document.querySelectorAll(`[data-pdf-annotate-id="${annotationId}"]`);
   let type = target[0].getAttribute('data-pdf-annotate-type');
   let svg = overlay.parentNode.querySelector('svg.annotationLayer');
-  let { documentId } = getMetadata(svg);
-  
+  let { documentId, pageNumber } = getMetadata(svg);
+
   overlay.querySelector('a').style.display = '';
 
   function getDelta(propX, propY) {
@@ -312,7 +313,7 @@ function handleDocumentMouseup(e) {
       appendChild(svg, annotation);
     }
 
-    PDFJSAnnotate.getStoreAdapter().editAnnotation(documentId, annotationId, annotation);
+    PDFJSAnnotate.getStoreAdapter().editAnnotation(documentId, pageNumber, annotation);
   });
 
   setTimeout(() => {
@@ -337,6 +338,16 @@ function handleAnnotationClick(target) {
 }
 
 /**
+ * Set the annotation being edited.
+ *
+ * @param {Element} e The annotation element that is to be edited
+ */
+export function setEdit (annotation) {
+  let target = document.querySelector(`[data-pdf-annotate-id='${annotation.id}']`);
+  fireEvent('annotation:click', target);
+}
+
+/**
  * Enable edit mode behavior.
  */
 export function enableEdit () {
@@ -357,4 +368,3 @@ export function disableEdit () {
   _enabled = false;
   removeEventListener('annotation:click', handleAnnotationClick);
 };
-

--- a/src/UI/event.js
+++ b/src/UI/event.js
@@ -26,6 +26,8 @@ document.addEventListener('click', function handleDocumentClick(e) {
   // Emit annotation:click if target was clicked
   if (target) {
     emitter.emit('annotation:click', target);
+  } else {
+    emitter.emit('document:click', e);
   }
 
   clickNode = target;

--- a/src/UI/index.js
+++ b/src/UI/index.js
@@ -1,5 +1,5 @@
 import { addEventListener, removeEventListener, fireEvent } from './event';
-import { disableEdit, enableEdit } from './edit';
+import { disableEdit, enableEdit, setEdit } from './edit';
 import { disablePen, enablePen, setPen } from './pen';
 import { disablePoint, enablePoint } from './point';
 import { disableRect, enableRect, setHighlight, setStrikeout, setArea } from './rect';
@@ -8,7 +8,7 @@ import { createPage, renderPage } from './page';
 
 export default {
   addEventListener, removeEventListener, fireEvent,
-  disableEdit, enableEdit,
+  disableEdit, enableEdit, setEdit,
   disablePen, enablePen, setPen,
   disablePoint, enablePoint,
   disableRect, enableRect, setHighlight, setStrikeout, setArea,

--- a/src/a11y/initEventHandlers.js
+++ b/src/a11y/initEventHandlers.js
@@ -12,12 +12,10 @@ export default function initEventHandlers() {
   addEventListener('annotation:add', (documentId, pageNumber, annotation) => {
     reorderAnnotationsByType(documentId, pageNumber, annotation.type);
   });
-  addEventListener('annotation:edit', (documentId, annotationId, annotation) => {
-    reorderAnnotationsByType(documentId, annotation.page, annotation.type);
+  addEventListener('annotation:edit', (documentId, pageNumber, annotation) => {
+    reorderAnnotationsByType(documentId, pageNumber, annotation.type);
   });
   addEventListener('annotation:delete', removeAnnotation);
-  addEventListener('comment:add', insertComment);
-  addEventListener('comment:delete', removeComment);
 }
 
 /**

--- a/src/adapter/StoreAdapter.js
+++ b/src/adapter/StoreAdapter.js
@@ -80,9 +80,9 @@ export default class StoreAdapter {
   __editAnnotation(documentId, pageNumber, annotation) { abstractFunction('editAnnotation'); }
   get editAnnotation() { return this.__editAnnotation; }
   set editAnnotation(fn) {
-    this.__editAnnotation = function editAnnotation(documentId, annotationId, annotation) {
+    this.__editAnnotation = function editAnnotation(documentId, pageNumber, annotation) {
       return fn(...arguments).then((annotation) => {
-        fireEvent('annotation:edit', documentId, annotationId, annotation);
+        fireEvent('annotation:edit', documentId, pageNumber, annotation);
         return annotation;
       });
     };


### PR DESCRIPTION
Adds event listeners and event handlers needed for correct behavior when selecting annotations or annotation comments. Edit overlays will be properly placed on the annotations corresponding to the selection. This also fixes several places where the incorrect parameter was used in the editAnnotation method (pageNumber should be passed instead).